### PR TITLE
Added django version 1.1 (tests not working with 2.0), fixed parameters

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,5 +50,6 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
 )

--- a/test_proj/requirements.txt
+++ b/test_proj/requirements.txt
@@ -1,1 +1,1 @@
-Django
+Django==1.11.2

--- a/video_encoding/backends/ffmpeg.py
+++ b/video_encoding/backends/ffmpeg.py
@@ -24,8 +24,11 @@ class FFmpegBackend(BaseEncodingBackend):
     name = 'FFmpeg'
 
     def __init__(self):
+
+        # Add -strict -2 parameters to support aac codec (which is experimental)
+        # This will fix errors in tests
         self.params = ['-threads', str(settings.VIDEO_ENCODING_THREADS),
-                       '-y']  # overwrite temporary created file
+                       '-y', '-strict', '-2']  # overwrite temporary created file
 
         self.ffmpeg_path = getattr(
             settings, 'VIDEO_ENCODING_FFMPEG_PATH', which('ffmpeg'))


### PR DESCRIPTION
- Added python 3.6 to supported languages
- Added django==1.11 as version to requirements file (django 2.0 is not compatible with this version)
- Added -strict -2 parameters to ffmpeg backend. Without this, method test_encode in test_proj/media_library/tests/test_ffmpeg_backend.py will fail with error message "video_encoding.exceptions.FFmpegError: File size of generated file is 0". 