### PR TITLE
Silence ffprobe debug output on stderr.

### DIFF
--- a/video_encoding/backends/ffmpeg.py
+++ b/video_encoding/backends/ffmpeg.py
@@ -148,6 +148,7 @@ class FFmpegBackend(BaseEncodingBackend):
         Return information about the given video.
         """
         cmd = [self.ffprobe_path, '-i', video_path]
+        cmd.extend(['-hide_banner',  '-loglevel', 'warning'])
         cmd.extend(['-print_format', 'json'])
         cmd.extend(['-show_format', '-show_streams'])
 


### PR DESCRIPTION
## Description

FFprobe outputs debug information to stderr by default. This clutters the application log and does not provide any benefit.
I added flags to hide the standard banner and set the log level to warning, so only relevant info is sent to stderr.

## Checklist

- [ ] Tests covering the new functionality have been added
- [ ] Code builds clean without any errors or warnings
- [ ] Documentation has been updated
- [ ] Changes have been added to the `CHANGELOG.md`
- [ ] You added yourself to the `CONTRIBUTORS.md`
