### PR TITLE
Do not break on invalid output from ffmpeg - fixes #38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * remove deprecation warnings
+* do not break on invalid characters from ffmpeg
 
 ### Removed
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,4 +5,5 @@
 * [@goranpavlovic](https://github.com/goranpavlovic)
 * [@lifenautjoe](https://github.com/lifenautjoe)
 * [@mabuelhagag](https://github.com/mabuelhagag)
+* [@ayushin](https://github.com/apexlabs-ai)
 

--- a/video_encoding/backends/ffmpeg.py
+++ b/video_encoding/backends/ffmpeg.py
@@ -94,12 +94,11 @@ class FFmpegBackend(BaseEncodingBackend):
 
         # update progress
         while process.poll() is None:  # is process terminated yet?
-            line = reader.readline()
-
             try:
+                line = reader.readline()
                 # format 00:00:00.00
                 time_str = RE_TIMECODE.findall(line)[0]
-            except IndexError:
+            except (UnicodeDecodeError, IndexError):
                 continue
 
             # convert time to seconds


### PR DESCRIPTION
ffmpeg sometimes outputs crazy non utf-8 characters coming from video metadata. There is no reason to stop processing because of that.

## Description

Please include a summary of the proposed changes.

Fixes #(issue)

## Checklist

- [ ] Tests covering the new functionality have been added
- [X] Code builds clean without any errors or warnings
- [X] Documentation has been updated
- [X] Changes have been added to the `CHANGELOG.md`
- [X ] You added yourself to the `CONTRIBUTORS.md`
